### PR TITLE
Improve config merge logic

### DIFF
--- a/gfd/utils.py
+++ b/gfd/utils.py
@@ -16,5 +16,6 @@ def process_config(file_path, args=argparse.Namespace()):
 
 
 def combine_config(config1, config2):
-    CombinedConfig = namedtuple('Config', config1._fields + config2._fields)
-    return CombinedConfig(*(config1 + config2))
+    """Merge two config namedtuples, preferring values from ``config2``."""
+    config = {**config1._asdict(), **config2._asdict()}
+    return namedtuple('Config', config.keys())(**config)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,26 @@
+import unittest
+from collections import namedtuple
+import importlib.util
+import os
+
+spec = importlib.util.spec_from_file_location(
+    "gfd.utils", os.path.join(os.path.dirname(__file__), "..", "gfd", "utils.py")
+)
+utils = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(utils)
+combine_config = utils.combine_config
+
+
+class TestCombineConfig(unittest.TestCase):
+    def test_combine_prefers_second(self):
+        Config1 = namedtuple('Config1', ['a', 'b'])
+        config1 = Config1(a=1, b=2)
+        Config2 = namedtuple('Config2', ['b', 'c'])
+        config2 = Config2(b=3, c=4)
+
+        combined = combine_config(config1, config2)
+
+        self.assertEqual(combined.a, 1)
+        self.assertEqual(combined.b, 3)
+        self.assertEqual(combined.c, 4)
+


### PR DESCRIPTION
## Summary
- refactor `combine_config` in utils to merge dictionaries
- add unit test covering merge behavior

## Testing
- `pytest tests/test_utils.py -q`
- `pytest -q` *(fails: ProxyError fetching HuggingFace model; CUDA missing)*

------
https://chatgpt.com/codex/tasks/task_e_685a5c2af8f083228725b5176b6324d2