### PR TITLE
Fix BOS handling in BreezperOCR

### DIFF
--- a/benchmarks/run_ocr_single_file.py
+++ b/benchmarks/run_ocr_single_file.py
@@ -1,5 +1,6 @@
 import argparse
 import json
+import os
 
 from gfd.gfd_ocr import BreezperOCR
 from gfd.utils import process_config
@@ -8,7 +9,12 @@ from gfd.utils import process_config
 def parse_args():
     parser = argparse.ArgumentParser(description="Run GFD OCR on a single image.")
     parser.add_argument('--image_file_path', type=str, required=True, help='Path to the image file')
-    parser.add_argument('--config', type=str, default='config_files/model/gfd-ocr-en.yaml', help='Path to config YAML')
+
+    default_config = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+        'config_files', 'model', 'gfd-ocr-en.yaml'
+    )
+    parser.add_argument('--config', type=str, default=default_config, help='Path to config YAML')
     parser.add_argument(
         '--result_output_path',
         type=str,

--- a/gfd/gfd_ocr.py
+++ b/gfd/gfd_ocr.py
@@ -69,6 +69,18 @@ class BreezperOCR:
 
     def _get_prefix_decoding_ids(self, asr_prompt, llm_prompt):
         asr_prefix_decoding_ids = self.asr_tokenizer(asr_prompt, add_special_tokens=False).input_ids
+        # TrOCR expects the decoder input to start with a special BOS token. When
+        # no prompt is provided the tokenized result could be an empty list which
+        # leads to a zero-length tensor passed to ``VisionEncoderDecoderModel``
+        # and causes a runtime error during ``view``.  Always prepend the
+        # ``decoder_start_token_id`` so there is at least one token.
+        decoder_start_id = self.recognizer.config.decoder_start_token_id
+        if decoder_start_id is not None:
+            asr_prefix_decoding_ids = [decoder_start_id] + asr_prefix_decoding_ids
+        elif not asr_prefix_decoding_ids:
+            # Fallback to 0 if ``decoder_start_token_id`` is not defined. This is
+            # the default BOS token id for many seq2seq models.
+            asr_prefix_decoding_ids = [0]
         llm_prefix_decoding_ids = self.llm_tokenizer.tokenize_from_byte(
             self.llm_prefix_template.format(prompt=llm_prompt).encode("utf8")
         )


### PR DESCRIPTION
## Summary
- ensure `BreezperOCR` always prepends a `decoder_start_token_id`
  so that the TrOCR decoder never receives an empty sequence
- fix default config path for OCR benchmark

## Testing
- `python -m py_compile gfd/gfd_ocr.py benchmarks/run_ocr_single_file.py`
- `pytest -q` *(fails: ProxyError from huggingface.co and CUDA driver not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ca37c56108322b3f0bc5ed5833afd